### PR TITLE
Fix failed build due to missing packages in PPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-devel
+FROM nvidia/cuda:8.0-devel-ubuntu14.04
 MAINTAINER support@arrayfire.com
 
 RUN apt-get update && apt-get install -y software-properties-common && \


### PR DESCRIPTION
The repository ppa:keithw/glfw3 currently does not provide packages for 16.04 which causes the Docker build to fail.
Building from the Ubuntu 14.04 Trusty image fixes the issue.